### PR TITLE
Always return code.  Fix typo.

### DIFF
--- a/R/gogoplot-server.R
+++ b/R/gogoplot-server.R
@@ -118,7 +118,7 @@ gogoplot_server <- function(.data, data_name) {
 
     # return plot object
     shiny::observeEvent(input$btn_plot, {
-      shiny::stopApp(invisible(plot()))
+      shiny::stopApp(plot())
     })
 
     # download plot image

--- a/R/gogoplot-server.R
+++ b/R/gogoplot-server.R
@@ -102,18 +102,23 @@ gogoplot_server <- function(.data, data_name) {
     # return plot code
     shiny::observeEvent(input$btn_code, {
       code_str <- paste0(plot_code(), collapse = " +\n  ")
+
       # return function call
       if(rstudioapi::isAvailable()){
         rstudioapi::insertText(text = code_str)
-        shiny::stopApp()
-      } else{
-        shiny::stopApp(code_str)
       }
-    })
+
+      # In addition to inserting text into an open document using the
+      # RStudio API, the application will always invisibly return
+      # the code string so it can be captured
+
+      shiny::stopApp(invisible(code_str))
+
+      })
 
     # return plot object
     shiny::observeEvent(input$btn_plot, {
-      shiny::stopApp(plot())
+      shiny::stopApp(invisible(plot()))
     })
 
     # download plot image

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ The current version of `gogoplot` has just one function - `plot_gadget()`. When 
 
 ```{r example, eval=FALSE}
 library(gogoplot)
-plot_gadget(mtcars)
+gogoplot(mtcars)
 ```
 
 ![gogoplot GUI](images/gogoplot.png)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The current version of `gogoplot` has just one function - `plot_gadget()`. When 
 
 ``` r
 library(gogoplot)
-plot_gadget(mtcars)
+gogoplot(mtcars)
 ```
 
 ![gogoplot GUI](images/gogoplot.png)


### PR DESCRIPTION
Hey @wcmbishop!  I'm really excited you're working on this!!!

I made a small adjustment to the code base so that the text is always invisibly returned.  This allows you to capture it in a variable.

Largely this was just a MVP to get a fork setup and start contributing to this project.

Thanks,

Aaron